### PR TITLE
Change replace to replaceAll for url slugs

### DIFF
--- a/src/app/apps/[slug]/page.tsx
+++ b/src/app/apps/[slug]/page.tsx
@@ -32,7 +32,7 @@ export default async function SingleApp({
   const apps = await getApps();
   const app: PodcastIndexApps | undefined = apps.find(
     (app: PodcastIndexApps) =>
-      app.appName.toLowerCase().replace(" ", "") === params.slug.toLowerCase(),
+      app.appName.toLowerCase().replaceAll(" ", "") === params.slug.toLowerCase(),
   );
   if (!app) {
     return notFound();

--- a/src/app/podcast-namespace/tags/[slug]/page.tsx
+++ b/src/app/podcast-namespace/tags/[slug]/page.tsx
@@ -142,7 +142,7 @@ export default async function SingleTag({
         <div className="mb-8 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
           {supportedPodcastPlayers.map((app) => (
             <Link
-              href={`/apps/${app.appName.toLowerCase().replace(" ", "")}`}
+              href={`/apps/${app.appName.toLowerCase().replaceAll(" ", "")}`}
               key={app.appName}
               className="flex items-center gap-2 rounded-md p-2 text-muted-foreground transition-all hover:bg-muted"
             >
@@ -171,7 +171,7 @@ export default async function SingleTag({
         <div className="mb-8 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
           {supportedPublishingTools.map((app) => (
             <Link
-              href={`/apps/${app.appName.toLowerCase().replace(" ", "")}`}
+              href={`/apps/${app.appName.toLowerCase().replaceAll(" ", "")}`}
               key={app.appName}
               className="flex items-center gap-2 rounded-md p-2 text-muted-foreground transition-all hover:bg-muted"
             >


### PR DESCRIPTION
Fixes broken link when clicking some apps/hosting providers on namespace pages

Can be seen with [current page](https://podcasting2.org/podcast-namespace/tags/chapters) by clicking on "PowerPress by Blubrry" or "Music Side Project". It isn't an issue with "Sovereign Feeds" since there is only one space.
