### PR TITLE
feat: Update links and descriptions in podcast guides

### DIFF
--- a/content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx
+++ b/content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx
@@ -39,14 +39,14 @@ If you're building a podcast app that supports timed captions, there are well-re
 
 ## Tools for generating transcripts
 
-(Sorted alphabetically. Some of the following links compensate Podcasting2.org _only_ for purchases made through these links. But no extra consideration is given based on earnings and we do not except compensation for inclusion.)
+(Sorted alphabetically. Some of the following links compensate Podcasting2.org _only_ for purchases made through these links. But no extra consideration is given based on earnings and we do not accept compensation for inclusion.)
 
 - [CastMagic](https://get.castmagic.io/h8md35zk8hn8?sid1=podcasting2.org) (web, paid)
 - [Descript](https://www.descript.com/?lmref=UHA3gA) (web, paid)
 - [Free Podcast Transcription](https://freepodcasttranscription.com), powered by Spreaker (web, free)
 - [Headliner](https://make.headliner.app/referral/mail_swwFpK) (web, paid)
 - [MacWhisper](https://gumroad.com/a/239419603/ivpqk) (macOS, free and paid)
-- [Otter](https://otterai.sjv.io/c/44407/1063514/13661?utm_term=1113693&utm_medium=tracking_link&utm_source=affiliate&utm_content=other) (web, paid)
+- [Otter](https://otterai.sjv.io/c/44407/1063514/13661?utm_term=ai_meeting_assistant_affiliate&utm_medium=tracking_link&utm_source=affiliate&utm_content=other&partnerpropertyid=7153126&MediaPartnerPropertyId=7153126) (web, paid)
 - [Whisper.cpp](https://github.com/ggml-org/whisper.cpp) (command line, free) - here's [how to install to your Mac](https://podnews.net/article/installation-whisper-macos)
 - [Whisper GUI](https://grisk.itch.io/whisper-gui) (Windows, free)
 

--- a/content/docs/guides/index.mdx
+++ b/content/docs/guides/index.mdx
@@ -11,7 +11,7 @@ description: "Helping you to use Podcasting 2.0 in your podcast and with your pu
 
 - [Podcasting 2.0 with Adam Curry, Dave Jones, and occasional guests](https://podcastindex.org/podcast/920666)
 - [The Future of Podcasting with Dave Jackson and Daniel J. Lewis](https://futureofpodcasting.net)
-- [Podcasting 2.0 in Pracice with Claire Waite Brown](https://www.creativityfound.co.uk/podcasting)
+- [Podcasting 2.0 in Practice with Claire Waite Brown](https://www.creativityfound.co.uk/podcasting)
 
 ## Blogs and articles
 


### PR DESCRIPTION
The changes in this commit update the links and descriptions in the podcast guides section of the documentation. Specifically:

- Update the link for the "Podcasting 2.0 in Practice" guide to use the correct URL.
- Correct a typo in the "Tools for generating transcripts" section, changing "except" to "accept".