### PR TITLE
feat(next.config): Add redirects for podcast namespace and tags

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -66,8 +66,18 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: "/podcast-namespace/tags/walletswitching",
+        destination: "/podcast-namespace/tags/valuetimesplit",
+        permanent: false,
+      },
+      {
         source: "/podcast-namespace/:path*",
         destination: "/docs/podcast-namespace/:path*",
+        permanent: true,
+      },
+      {
+        source: "/tags/:path*",
+        destination: "/docs/podcast-namespace/tags/:path*",
         permanent: true,
       },
       {


### PR DESCRIPTION
Added a /tags/* 301 redirect, allowing https://podcasting2.org/tags/podroll to go to https://podcasting2.org/docs/podcast-namespace/tags/podroll