### PR TITLE
feat(docs): update podcast namespace repo user

### DIFF
--- a/src/app/docs/podcast-namespace/[[...mdxPath]]/page.tsx
+++ b/src/app/docs/podcast-namespace/[[...mdxPath]]/page.tsx
@@ -11,7 +11,7 @@ import { importPage } from "nextra/pages";
 import { useMDXComponents as getMDXComponents } from "@/../mdx-components";
 import { AppsGrid } from "@/components/AppsGrid";
 
-const user = "Podcastindex-org";
+const user = process.env.NAMESPACE_REPO_USER;
 const repo = "podcast-namespace";
 const branch = "refs/heads/main";
 const docsPath = "/docs/";


### PR DESCRIPTION
Updates the podcast namespace repository user to use the
environment variable `NAMESPACE_REPO_USER` instead of a
hardcoded value. This allows for more flexibility and
easier configuration of the repository user.