### PR TITLE
Avoid redirect with final URL

### DIFF
--- a/content/docs/podcast-namespace/index.mdx
+++ b/content/docs/podcast-namespace/index.mdx
@@ -10,7 +10,7 @@ date: 2025-04-01
 
 `<rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">{:xml}`
 
-Since the [first podcast](https://blogs.harvard.edu/lydondev/2003/07/09/spoken-word-a-few-good-bloggers/) in 2003, podcasting has been evolving.
+Since the [first podcast](https://archive.blogs.harvard.edu/lydondev/2003/07/09/spoken-word-a-few-good-bloggers/) in 2003, podcasting has been evolving.
 
 The open podcast ecosystem is powered by RSS feeds. RSS ("really simple syndication") can be extended with a "namespace", a set of new tags that enable new features. Apple added [their own iTunes podcast namespace in 2005](https://podcasters.apple.com/support/823-podcast-requirements), which allowed podcasters to specify things like podcast artwork, categories, and other elements. Other namespaces have also been proposed; but in 2020, a new, collaborative, podcast namespace was first worked on by a wide number of interested people, aided and encouraged by Adam Curry and Dave Jones from [The Podcast Index](https://podcastindex.org/).
 


### PR DESCRIPTION
https://blogs.harvard.edu/lydondev/2003/07/09/spoken-word-a-few-good-bloggers/ redirects to  https://archive.blogs.harvard.edu/lydondev/2003/07/09/spoken-word-a-few-good-bloggers/