### PR TITLE
feat(build): Update nixpkgs archive and add nodejs and bun packages

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,2 +1,3 @@
 [phases.setup]
-nixpkgsArchive = "477d26d111feea02901d740cb4b9cae3b679e8d9"
+nixpkgsArchive = "master"
+nixPkgs = ['nodejs_22', 'bun']


### PR DESCRIPTION
Modify nixpacks configuration to use the latest master branch of nixpkgs
and explicitly include nodejs 22 and bun packages for build environment.
This ensures more up-to-date dependencies and clearer package selection.