### PR TITLE
Add Transcreve BR to transcript tools

### DIFF
--- a/content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx
+++ b/content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx
@@ -47,6 +47,7 @@ If you're building a podcast app that supports timed captions, there are well-re
 - [MacWhisper](https://gumroad.com/a/239419603/ivpqk) (macOS, free and paid)
 - [Otter](https://otterai.sjv.io/c/44407/1063514/13661?utm_term=ai_meeting_assistant_affiliate&utm_medium=tracking_link&utm_source=affiliate&utm_content=other&partnerpropertyid=7153126&MediaPartnerPropertyId=7153126) (web, paid)
 - [PodChapters](https://podchapters.com/)
+- [Transcreve BR by BRAINIALL](https://www.brainiall.com/transcreve/podcast-para-vtt?utm_source=podcasting2&utm_medium=editorial&utm_campaign=c6_podcast_transcript_tools) (web, paid; exports VTT and SRT)
 - [Whisper.cpp](https://github.com/ggml-org/whisper.cpp) (command line, free) - here's [how to install to your Mac](https://podnews.net/article/installation-whisper-macos)
 - [Whisper GUI](https://grisk.itch.io/whisper-gui) (Windows, free)
 


### PR DESCRIPTION
## Summary

- adds Transcreve BR by BRAINIALL to the alphabetized transcript-generation tools list
- links directly to its podcast-to-VTT workflow, which exports VTT and SRT

## Why

This gives podcasters another web-based option for creating transcript files in the formats recommended by this guide.

## Disclosure

BRAINIALL maintains Transcreve BR, and this contribution is submitted by the BRAINIALL Team. The destination URL includes UTM parameters for attribution. This PR does not claim or imply endorsement by Podcasting2.org; inclusion is entirely subject to maintainer review.

## Validation

- `bunx prettier --check content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx` passes
- the linked destination responds with HTTP 200 and describes VTT/SRT export
- `bun run build` compiles successfully and completes lint/type checking, then fails during page-data collection on the unchanged `upstream/master` baseline because `_meta` refers to a missing `tags` page

Only `content/docs/guides/how-to-add-transcripts-to-your-podcast.mdx` is changed (one insertion).
